### PR TITLE
Mccalluc/dont depend on flask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-Flask==2.0.1
 vitessce==0.1.0a12
 hubmap-commons==2.0.12

--- a/src/builder_factory.py
+++ b/src/builder_factory.py
@@ -17,9 +17,9 @@ from .assays import (
 )
 
 
-def get_view_config_builder(entity, assay_map):
+def get_view_config_builder(entity, get_assay):
     data_types = entity["data_types"]
-    assay_objs = [assay_map[dt] for dt in data_types]
+    assay_objs = [get_assay(dt) for dt in data_types]
     assay_names = [assay.name for assay in assay_objs]
     hints = [hint for assay in assay_objs for hint in assay.vitessce_hints]
     dag_names = [dag['name']

--- a/src/builder_factory.py
+++ b/src/builder_factory.py
@@ -1,6 +1,3 @@
-from flask import current_app
-from hubmap_commons.type_client import TypeClient
-
 from .builders.base_builders import NullViewConfBuilder
 from .builders.sprm_builders import (
     StitchedCytokitSPRMViewConfBuilder, TiledSPRMViewConfBuilder
@@ -20,27 +17,9 @@ from .assays import (
 )
 
 
-_assays = None
-
-
-def _get_assay(data_type):
-    "Return the assay class for the given data type"
-    global _assays
-
-    type_client = TypeClient(current_app.config["TYPE_SERVICE_ENDPOINT"])
-    if _assays is None:
-        # iterAssays does not include deprecated assay names...
-        _assays = {assay.name: assay for assay in type_client.iterAssays()}
-
-    if data_type not in _assays:
-        # ... but getAssayType does handle deprecated names:
-        _assays[data_type] = type_client.getAssayType(data_type)
-    return _assays[data_type]
-
-
-def get_view_config_builder(entity):
+def get_view_config_builder(entity, assay_map):
     data_types = entity["data_types"]
-    assay_objs = [_get_assay(dt) for dt in data_types]
+    assay_objs = [assay_map[dt] for dt in data_types]
     assay_names = [assay.name for assay in assay_objs]
     hints = [hint for assay in assay_objs for hint in assay.vitessce_hints]
     dag_names = [dag['name']

--- a/src/builders/anndata_builders.py
+++ b/src/builders/anndata_builders.py
@@ -13,8 +13,8 @@ class RNASeqAnnDataZarrViewConfBuilder(ViewConfBuilder):
     https://portal.hubmapconsortium.org/browse/dataset/e65175561b4b17da5352e3837aa0e497
     """
 
-    def __init__(self, entity, groups_token, **kwargs):
-        super().__init__(entity, groups_token, **kwargs)
+    def __init__(self, entity, groups_token, assets_endpoint, **kwargs):
+        super().__init__(entity, groups_token, assets_endpoint, **kwargs)
         # Spatially resolved RNA-seq assays require some special handling,
         # and others do not.
         self._is_spatial = False
@@ -76,8 +76,8 @@ class SpatialRNASeqAnnDataZarrViewConfBuilder(RNASeqAnnDataZarrViewConfBuilder):
     https://portal.hubmapconsortium.org/browse/dataset/e65175561b4b17da5352e3837aa0e497
     """
 
-    def __init__(self, entity, groups_token, **kwargs):
-        super().__init__(entity, groups_token, **kwargs)
+    def __init__(self, entity, groups_token, assets_endpoint, **kwargs):
+        super().__init__(entity, groups_token, assets_endpoint, **kwargs)
         # Spatially resolved RNA-seq assays require some special handling,
         # and others do not.
         self._is_spatial = True

--- a/src/builders/base_builders.py
+++ b/src/builders/base_builders.py
@@ -1,14 +1,12 @@
 import urllib
 from collections import namedtuple
 
-from flask import current_app
-
 
 ConfCells = namedtuple('ConfCells', ['conf', 'cells'])
 
 
 class NullViewConfBuilder():
-    def __init__(self, entity, groups_token, **kwargs):
+    def __init__(self, entity, groups_token, assets_endpoint, **kwargs):
         # Just so it has the same signature as the other builders
         pass
 
@@ -17,7 +15,7 @@ class NullViewConfBuilder():
 
 
 class ViewConfBuilder:
-    def __init__(self, entity, groups_token, **kwargs):
+    def __init__(self, entity, groups_token, assets_endpoint, **kwargs):
         """Object for building the vitessce configuration.
         :param dict entity: Entity response from search index (from the entity API)
         :param str groups_token: Groups token for use in authenticating API
@@ -29,6 +27,7 @@ class ViewConfBuilder:
 
         self._uuid = entity["uuid"]
         self._groups_token = groups_token
+        self._assets_endpoint = assets_endpoint
         self._entity = entity
         self._files = []
 
@@ -73,8 +72,7 @@ class ViewConfBuilder:
         'https://example.com/uuid/rel_path/to/clusters.ome.tiff?token=groups_token'
 
         """
-        assets_endpoint = current_app.config["ASSETS_ENDPOINT"]
-        base_url = urllib.parse.urljoin(assets_endpoint, f"{self._uuid}/{rel_path}")
+        base_url = urllib.parse.urljoin(self._assets_endpoint, f"{self._uuid}/{rel_path}")
         token_param = urllib.parse.urlencode({"token": self._groups_token})
         return f"{base_url}?{token_param}" if use_token else base_url
 

--- a/src/builders/imaging_builders.py
+++ b/src/builders/imaging_builders.py
@@ -53,13 +53,13 @@ class AbstractImagingViewConfBuilder(ViewConfBuilder):
 
 
 class ImagePyramidViewConfBuilder(AbstractImagingViewConfBuilder):
-    def __init__(self, entity, groups_token, **kwargs):
+    def __init__(self, entity, groups_token, assets_endpoint, **kwargs):
         """Wrapper class for creating a standard view configuration for image pyramids,
         i.e for high resolution viz-lifted imaging datasets like
         https://portal.hubmapconsortium.org/browse/dataset/dc289471333309925e46ceb9bafafaf4
         """
         self.image_pyramid_regex = IMAGE_PYRAMID_DIR
-        super().__init__(entity, groups_token, **kwargs)
+        super().__init__(entity, groups_token, assets_endpoint, **kwargs)
 
     def get_conf_cells(self):
         file_paths_found = self._get_file_paths()
@@ -101,8 +101,8 @@ class IMSViewConfBuilder(ImagePyramidViewConfBuilder):
     of all the channels separated out.
     """
 
-    def __init__(self, entity, groups_token, **kwargs):
-        super().__init__(entity, groups_token, **kwargs)
+    def __init__(self, entity, groups_token, assets_endpoint, **kwargs):
+        super().__init__(entity, groups_token, assets_endpoint, **kwargs)
         # Do not show the separated mass-spec images.
         self.image_pyramid_regex = (
             re.escape(IMAGE_PYRAMID_DIR) + r"(?!/ometiffs/separate/)"

--- a/src/builders/scatterplot_builders.py
+++ b/src/builders/scatterplot_builders.py
@@ -45,8 +45,8 @@ class RNASeqViewConfBuilder(AbstractScatterplotViewConfBuilder):
     from h5ad-to-arrow.cwl (August 2020 release).
     """
 
-    def __init__(self, entity, groups_token, **kwargs):
-        super().__init__(entity, groups_token, **kwargs)
+    def __init__(self, entity, groups_token, assets_endpoint, **kwargs):
+        super().__init__(entity, groups_token, assets_endpoint, **kwargs)
         # All "file" Vitessce objects that do not have wrappers.
         self._files = [
             {
@@ -68,8 +68,8 @@ class ATACSeqViewConfBuilder(AbstractScatterplotViewConfBuilder):
     from h5ad-to-arrow.cwl.
     """
 
-    def __init__(self, entity, groups_token, **kwargs):
-        super().__init__(entity, groups_token, **kwargs)
+    def __init__(self, entity, groups_token, assets_endpoint, **kwargs):
+        super().__init__(entity, groups_token, assets_endpoint, **kwargs)
         # All "file" Vitessce objects that do not have wrappers.
         self._files = [
             {

--- a/src/builders/sprm_builders.py
+++ b/src/builders/sprm_builders.py
@@ -64,9 +64,9 @@ class SPRMJSONViewConfBuilder(SPRMViewConfBuilder):
     https://portal.hubmapconsortium.org/browse/dataset/dc31a6d06daa964299224e9c8d6cafb3
     """
 
-    def __init__(self, entity, groups_token, **kwargs):
+    def __init__(self, entity, groups_token, assets_endpoint, **kwargs):
         # All "file" Vitessce objects that do not have wrappers.
-        super().__init__(entity, groups_token, **kwargs)
+        super().__init__(entity, groups_token, assets_endpoint, **kwargs)
         # These are both something like R001_X009_Y009 because
         # there is no mask used here or shared name with the mask data.
         self._base_name = kwargs["base_name"]
@@ -142,8 +142,8 @@ class SPRMAnnDataViewConfBuilder(SPRMViewConfBuilder):
     of the image and mask relative to image_pyramid_regex
     """
 
-    def __init__(self, entity, groups_token, **kwargs):
-        super().__init__(entity, groups_token, **kwargs)
+    def __init__(self, entity, groups_token, assets_endpoint, **kwargs):
+        super().__init__(entity, groups_token, assets_endpoint, **kwargs)
         self._base_name = kwargs["base_name"]
         self._mask_name = kwargs["mask_name"]
         self._image_name = kwargs["image_name"]
@@ -241,6 +241,7 @@ class StitchedCytokitSPRMViewConfBuilder(ViewConfBuilder):
             vc = SPRMAnnDataViewConfBuilder(
                 entity=self._entity,
                 groups_token=self._groups_token,
+                assets_endpoint=self._assets_endpoint,
                 base_name=region,
                 imaging_path=STITCHED_IMAGE_DIR,
                 mask_path=STITCHED_IMAGE_DIR.replace('expressions', 'mask'),
@@ -265,11 +266,8 @@ class TiledSPRMViewConfBuilder(ViewConfBuilder):
 
     def get_conf_cells(self):
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
-        found_tiles = get_matches(
-            file_paths_found,
-            TILE_REGEX) or get_matches(
-            file_paths_found,
-            STITCHED_REGEX)
+        found_tiles = (get_matches(file_paths_found, TILE_REGEX)
+                       or get_matches(file_paths_found, STITCHED_REGEX))
         if len(found_tiles) == 0:
             message = f'Cytokit SPRM assay with uuid {self._uuid} has no matching tiles'
             raise FileNotFoundError(message)
@@ -278,6 +276,7 @@ class TiledSPRMViewConfBuilder(ViewConfBuilder):
             vc = SPRMJSONViewConfBuilder(
                 entity=self._entity,
                 groups_token=self._groups_token,
+                assets_endpoint=self._assets_endpoint,
                 base_name=tile,
                 imaging_path=CODEX_TILE_DIR
             )

--- a/test.sh
+++ b/test.sh
@@ -15,5 +15,5 @@ flake8 || die "Try: autopep8 --in-place --aggressive -r . --exclude $EXCLUDE"
 end flake8
 
 start pytest
-PYTHONPATH=. pytest .
+PYTHONPATH=. pytest . -vv
 end pytest

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -2,7 +2,8 @@ import json
 from pathlib import Path
 
 import pytest
-from flask import Flask
+
+from hubmap_commons.type_client import TypeClient
 
 from src.builder_factory import get_view_config_builder
 
@@ -11,21 +12,28 @@ entity_paths = list((Path(__file__).parent / 'fixtures').glob("*/*-entity.json")
 assert len(entity_paths) > 0
 
 
+type_client = TypeClient('https://search.api.hubmapconsortium.org')
+assay_map = {assay.name: assay for assay in type_client.iterAssays()}
+# if _assays is None:
+#     # iterAssays does not include deprecated assay names...
+#     _assays = {assay.name: assay for assay in type_client.iterAssays()}
+
+# if data_type not in _assays:
+#     # ... but getAssayType does handle deprecated names:
+#     _assays[data_type] = type_client.getAssayType(data_type)
+# return _assays[data_type]
+
 @pytest.mark.parametrize(
     "entity_path", entity_paths, ids=lambda path: f'{path.parent.name}/{path.name}')
 def test_entity_to_vitessce_conf(entity_path):
-    app = Flask(__name__)
-    app.config['TYPE_SERVICE_ENDPOINT'] = 'https://search.api.hubmapconsortium.org'
-    app.config['ASSETS_ENDPOINT'] = 'https://example.com'
-    with app.app_context():
-        entity = json.loads(entity_path.read_text())
-        Builder = get_view_config_builder(entity)
-        assert Builder.__name__ == entity_path.parent.name
+    entity = json.loads(entity_path.read_text())
+    Builder = get_view_config_builder(entity, assay_map)
+    assert Builder.__name__ == entity_path.parent.name
 
-        builder = Builder(entity, "groups_token")
-        conf = builder.get_conf_cells().conf
+    builder = Builder(entity, 'groups_token', 'https://example.com/')
+    conf = builder.get_conf_cells().conf
 
-        conf_expected_path = entity_path.parent / entity_path.name.replace('-entity', '-conf')
-        conf_expected = json.loads(conf_expected_path.read_text())
+    conf_expected_path = entity_path.parent / entity_path.name.replace('-entity', '-conf')
+    conf_expected = json.loads(conf_expected_path.read_text())
 
-        assert conf_expected == conf
+    assert conf_expected == conf

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -14,14 +14,10 @@ assert len(entity_paths) > 0
 
 type_client = TypeClient('https://search.api.hubmapconsortium.org')
 assay_map = {assay.name: assay for assay in type_client.iterAssays()}
-# if _assays is None:
-#     # iterAssays does not include deprecated assay names...
-#     _assays = {assay.name: assay for assay in type_client.iterAssays()}
+special_cases = ['MALDI-IMS-neg']  # TODO: How can we avoid pre-specifying this?
+for name in special_cases:
+    assay_map[name] = type_client.getAssayType(name)
 
-# if data_type not in _assays:
-#     # ... but getAssayType does handle deprecated names:
-#     _assays[data_type] = type_client.getAssayType(data_type)
-# return _assays[data_type]
 
 @pytest.mark.parametrize(
     "entity_path", entity_paths, ids=lambda path: f'{path.parent.name}/{path.name}')

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -12,18 +12,18 @@ entity_paths = list((Path(__file__).parent / 'fixtures').glob("*/*-entity.json")
 assert len(entity_paths) > 0
 
 
-type_client = TypeClient('https://search.api.hubmapconsortium.org')
-assay_map = {assay.name: assay for assay in type_client.iterAssays()}
-special_cases = ['MALDI-IMS-neg']  # TODO: How can we avoid pre-specifying this?
-for name in special_cases:
-    assay_map[name] = type_client.getAssayType(name)
+def get_assay(name):
+    # This code could also be used in portal-ui.
+    # search-api might skip the REST interface.
+    type_client = TypeClient('https://search.api.hubmapconsortium.org')
+    return type_client.getAssayType(name)
 
 
 @pytest.mark.parametrize(
     "entity_path", entity_paths, ids=lambda path: f'{path.parent.name}/{path.name}')
 def test_entity_to_vitessce_conf(entity_path):
     entity = json.loads(entity_path.read_text())
-    Builder = get_view_config_builder(entity, assay_map)
+    Builder = get_view_config_builder(entity, get_assay)
     assert Builder.__name__ == entity_path.parent.name
 
     builder = Builder(entity, 'groups_token', 'https://example.com/')


### PR DESCRIPTION
Two pieces of information that were pulled from the Flask context are now provided directly:
- `assay_map` provided when calling the factory: `Builder = get_view_config_builder(entity, assay_map)`
- `assets_endpoint` provided when constructing the builder: `builder = Builder(entity, groups_token, assets_endpoint)`

One problem: How can I get a complete `assay_map`? Right now, `type_client.iterAssays()` doesn't return all the names that are used, and they need to be added when they are seen: Is there some way to get a mapping for all names at once? Keep as draft until resolved.

- Fixes https://github.com/hubmapconsortium/portal-visualization/issues/4
- Unblocks https://github.com/hubmapconsortium/search-api/pull/442

----

Update: Talked with Joel, and he doesn't think providing a map for all names is a good direction. No problem: In the last commit I change the interface so a user will need to pass in a function instead of a dict.
