### PR TITLE
Target 3.9 on github CI; Loosen upper bounds on dependencies

### DIFF
--- a/.github/workflows/portal-ci.yml
+++ b/.github/workflows/portal-ci.yml
@@ -14,10 +14,10 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
         architecture: 'x64'
 
     - name: Install python main dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,15 +18,15 @@ scripts =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     vitessce==1.0.8
     hubmap-commons>=2.0.12
     requests>=2.27.1
     nbformat==5.1.3
-    zarr<=2.8.3 # For python3.6
+    zarr>=2.8.0
     aiohttp>=3.8.1
-    fsspec<=2022.1.0 # For python3.6
+    fsspec>=2022.1.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
- We've bumped the portal to 3.9, so it will reduce surprises to also test this under 3.9. (see https://github.com/hubmapconsortium/portal-ui/pull/2664)
- I've given up trying to get compatibility with 3.6, so loosen the restrictions in setup.py... Nothing needs these right now, but dropping the backward compatibility now may save us trouble in the future. (see https://github.com/hubmapconsortium/portal-visualization/pull/48#discussion_r874849801)