### PR TITLE
Eliminate unneeded conditional

### DIFF
--- a/src/portal_visualization/builders/anndata_builders.py
+++ b/src/portal_visualization/builders/anndata_builders.py
@@ -52,12 +52,7 @@ class RNASeqAnnDataZarrViewConfBuilder(ViewConfBuilder):
                 # If the dataset didn't have Azimuth annotations, it would be b'\x00'.
                 cell_set_obs.append("predicted.ASCT.celltype")
                 cell_set_obs_names.append("Predicted ASCT Cell Type")
-        # Check for an alias for gene names to add to the view config.
-        # Only pass group key in headers if needed.
-        kwargs_zarr = {}
-        if 'headers' in request_init:
-            kwargs_zarr['storage_options'] = {'client_kwargs': request_init}
-        z = zarr.open(adata_url, mode='r', **kwargs_zarr)
+        z = zarr.open(adata_url, mode='r', storage_options={'client_kwargs': request_init})
         gene_alias = 'var/hugo_symbol' if 'var' in z and 'hugo_symbol' in z['var'] else None
         dataset = vc.add_dataset(name=self._uuid).add_object(AnnDataWrapper(
             adata_url=adata_url,


### PR DESCRIPTION
Thanks for fixing the original problem, Ilan! Here's a tweak: I've tested it with a published dataset, and the extra kwarg doesn't hurt anything:
```
src/vis-preview.py --url https://portal.hubmapconsortium.org/browse/dataset/c05a38c5210b870281b5aea01e290339.json
```

I think your original impulse was good... something like: "If an existing case is working, then let's make sure it keeps working exactly the same way"... But the downside is that adding conditionals makes the code more brittle in other ways. Each additional code path means more potential variation between runs, and more code for future maintainers to worry about.

I could be off-base... Maybe schedule a call to talk if I'm confused and this isn't going in the right direction.