### PR TITLE
stub out a demonstration of how integrative analysis could work

### DIFF
--- a/src/portal_visualization/builder_factory.py
+++ b/src/portal_visualization/builder_factory.py
@@ -25,6 +25,9 @@ def get_view_config_builder(entity, get_assay):
     hints = [hint for assay in assay_objs for hint in assay.vitessce_hints]
     dag_names = [dag['name']
                  for dag in entity['metadata']['dag_provenance_list'] if 'name' in dag]
+    if 'integrative' in hints:
+        # TODO: confirm the string to be used in the hint.
+        return IntegrativeViewConfBuilder
     if "is_image" in hints:
         if 'sprm' in hints and 'anndata' in hints:
             return MultiImageSPRMAnndataViewConfBuilder

--- a/src/portal_visualization/builders/integrative_builders.py
+++ b/src/portal_visualization/builders/integrative_builders.py
@@ -1,0 +1,18 @@
+from vitessce import VitessceConfig
+
+from .base_builders import ViewConfBuilder
+from ..utils import get_conf_cells
+
+
+class IntegrativeViewConfBuilder(ViewConfBuilder):
+    # TODO: Add a test fixture.
+    # TODO: Determine the name of the property that will hold the viewconfs.
+    # TODO: If https://github.com/hubmapconsortium/portal-visualization/pull/66
+    #       arrives first this can be replaced with:
+    # def get_configs(self):
+    #     return [
+    #         VitessceConfig.from_dict(conf)
+    #         for conf in self._entity['viewconfs']
+    #     ]
+    def get_conf_cells(self):
+        return get_conf_cells(self._entity['viewconfs'])


### PR DESCRIPTION
Yesterday morning I had thought that the new thing would just be a composition of datasets... but if it actually embeds a viewconf, then it's reasonable for it to be handled here: It won't take much code, and this will let us:
- set the `has_visualization` facet at index time. (I think that's the name?)
- catch some errors at index time?
- use `vis_preview.py` consistently. (I think the pipeline developers have used it to preview the dataset before publication.)

FWIW: I'd go for a longer vitessce hint string than just `uia`: Bytes are cheap! Comprehension is expensive!

Filing as draft: Prereqs need to be in place before this can be used.