### PR TITLE
[HMP-78] Handle entities with no metadata in view config builder factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode
+.VSCode

--- a/src/portal_visualization/builder_factory.py
+++ b/src/portal_visualization/builder_factory.py
@@ -23,8 +23,9 @@ def get_view_config_builder(entity, get_assay):
     assay_objs = [get_assay(dt) for dt in data_types]
     assay_names = [assay.name for assay in assay_objs]
     hints = [hint for assay in assay_objs for hint in assay.vitessce_hints]
+    dag_provenance_list = entity.get('metadata', {}).get('dag_provenance_list', [])
     dag_names = [dag['name']
-                 for dag in entity['metadata']['dag_provenance_list'] if 'name' in dag]
+                 for dag in dag_provenance_list if 'name' in dag]
     if "is_image" in hints:
         if 'sprm' in hints and 'anndata' in hints:
             return MultiImageSPRMAnndataViewConfBuilder

--- a/test/good-fixtures/NullViewConfBuilder/missing-metadata.json
+++ b/test/good-fixtures/NullViewConfBuilder/missing-metadata.json
@@ -1,0 +1,3 @@
+{
+    "data_types": ["publication_ancillary"]
+  }

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -48,7 +48,8 @@ def get_assay(name):
     "has_vis_entity",
     [
         (False, {'data_types': [], 'metadata': {'dag_provenance_list': []}}),
-        (True, json.loads(Path.read_text(good_entity_paths[0])))
+        (True, json.loads(Path.read_text(good_entity_paths[0]))),
+        (False, {'data_types': []})
         # If the first fixture returns a Null builder this would break.
     ],
     ids=lambda has_vis_entity: f'has_visualization={has_vis_entity[0]}')


### PR DESCRIPTION
Some entities, such as publication_ancillary data types, do not have a metadata field and should be handled by the NullViewConfBuilder.

Adds VS Code artifacts to .gitignore.
Adds __init__.py so VS Code finds pytests.