### PR TITLE
(feat): add `use_full_resolution` feature for NanoDESI

### DIFF
--- a/src/portal_visualization/assays.py
+++ b/src/portal_visualization/assays.py
@@ -3,7 +3,7 @@ CODEX_CYTOKIT = "codex_cytokit"
 SEQFISH = "seqFish"
 MALDI_IMS = "MALDI-IMS"
 CELLDIVE_DEEPCELL = "celldive_deepcell"
-
+NANODESI = "NanoDESI"
 SCRNA_SEQ_10X = "salmon_rnaseq_10x"
 SCRNA_SEQ_SCI = "salmon_rnaseq_sciseq"
 SCRNA_SEQ_SNARE = "salmon_rnaseq_snareseq"

--- a/src/portal_visualization/builder_factory.py
+++ b/src/portal_visualization/builder_factory.py
@@ -4,7 +4,10 @@ from .builders.sprm_builders import (
     MultiImageSPRMAnndataViewConfBuilder
 )
 from .builders.imaging_builders import (
-    SeqFISHViewConfBuilder, IMSViewConfBuilder, ImagePyramidViewConfBuilder, NanoDESIViewConfBuilder
+    SeqFISHViewConfBuilder,
+    IMSViewConfBuilder,
+    ImagePyramidViewConfBuilder,
+    NanoDESIViewConfBuilder
 )
 from .builders.anndata_builders import (
     SpatialRNASeqAnnDataZarrViewConfBuilder, RNASeqAnnDataZarrViewConfBuilder

--- a/src/portal_visualization/builder_factory.py
+++ b/src/portal_visualization/builder_factory.py
@@ -4,7 +4,7 @@ from .builders.sprm_builders import (
     MultiImageSPRMAnndataViewConfBuilder
 )
 from .builders.imaging_builders import (
-    SeqFISHViewConfBuilder, IMSViewConfBuilder, ImagePyramidViewConfBuilder
+    SeqFISHViewConfBuilder, IMSViewConfBuilder, ImagePyramidViewConfBuilder, NanoDESIConfBuilder
 )
 from .builders.anndata_builders import (
     SpatialRNASeqAnnDataZarrViewConfBuilder, RNASeqAnnDataZarrViewConfBuilder
@@ -14,7 +14,8 @@ from .builders.scatterplot_builders import (
 )
 from .assays import (
     SEQFISH,
-    MALDI_IMS
+    MALDI_IMS,
+    NANODESI
 )
 
 
@@ -37,6 +38,8 @@ def get_view_config_builder(entity, get_assay):
             return SeqFISHViewConfBuilder
         if MALDI_IMS in assay_names:
             return IMSViewConfBuilder
+        if NANODESI in str(entity): # very bad hack
+            return NanoDESIConfBuilder
         return ImagePyramidViewConfBuilder
     if "rna" in hints:
         # This is the zarr-backed anndata pipeline.

--- a/src/portal_visualization/builder_factory.py
+++ b/src/portal_visualization/builder_factory.py
@@ -4,7 +4,7 @@ from .builders.sprm_builders import (
     MultiImageSPRMAnndataViewConfBuilder
 )
 from .builders.imaging_builders import (
-    SeqFISHViewConfBuilder, IMSViewConfBuilder, ImagePyramidViewConfBuilder, NanoDESIConfBuilder
+    SeqFISHViewConfBuilder, IMSViewConfBuilder, ImagePyramidViewConfBuilder, NanoDESIViewConfBuilder
 )
 from .builders.anndata_builders import (
     SpatialRNASeqAnnDataZarrViewConfBuilder, RNASeqAnnDataZarrViewConfBuilder
@@ -39,7 +39,7 @@ def get_view_config_builder(entity, get_assay):
         if MALDI_IMS in assay_names:
             return IMSViewConfBuilder
         if NANODESI in str(entity):  # very bad hack
-            return NanoDESIConfBuilder
+            return NanoDESIViewConfBuilder
         return ImagePyramidViewConfBuilder
     if "rna" in hints:
         # This is the zarr-backed anndata pipeline.

--- a/src/portal_visualization/builder_factory.py
+++ b/src/portal_visualization/builder_factory.py
@@ -37,11 +37,14 @@ def get_view_config_builder(entity, get_assay):
             if ('sprm-to-anndata.cwl' in dag_names):
                 return StitchedCytokitSPRMViewConfBuilder
             return TiledSPRMViewConfBuilder
+        # Both SeqFISH and IMS were submitted very early on, before the
+        # special image pyramid datasets existed.  Their assay names should be in
+        # the `entity["data_types"]` while newer ones, like NanoDESI, are in the parents
         if SEQFISH in assay_names:
             return SeqFISHViewConfBuilder
         if MALDI_IMS in assay_names:
             return IMSViewConfBuilder
-        if NANODESI in str(entity):  # very bad hack
+        if NANODESI in [dt for e in entity["immediate_ancestors"] for dt in e["data_types"]]:
             return NanoDESIViewConfBuilder
         return ImagePyramidViewConfBuilder
     if "rna" in hints:

--- a/src/portal_visualization/builder_factory.py
+++ b/src/portal_visualization/builder_factory.py
@@ -38,7 +38,7 @@ def get_view_config_builder(entity, get_assay):
             return SeqFISHViewConfBuilder
         if MALDI_IMS in assay_names:
             return IMSViewConfBuilder
-        if NANODESI in str(entity): # very bad hack
+        if NANODESI in str(entity):  # very bad hack
             return NanoDESIConfBuilder
         return ImagePyramidViewConfBuilder
     if "rna" in hints:

--- a/src/portal_visualization/builders/imaging_builders.py
+++ b/src/portal_visualization/builders/imaging_builders.py
@@ -92,7 +92,12 @@ class ImagePyramidViewConfBuilder(AbstractImagingViewConfBuilder):
                     img_url=img_url, offsets_url=offsets_url, name=Path(img_path).name
                 )
             )
-        dataset = dataset.add_object(MultiImageWrapper(images, use_physical_size_scaling=self.use_physical_size_scaling))
+        dataset = dataset.add_object(
+            MultiImageWrapper(
+                images,
+                use_physical_size_scaling=self.use_physical_size_scaling
+            )
+        )
         vc = self._setup_view_config_raster(vc, dataset)
         conf = vc.to_dict()
         # Don't want to render all layers
@@ -113,11 +118,13 @@ class IMSViewConfBuilder(ImagePyramidViewConfBuilder):
             re.escape(IMAGE_PYRAMID_DIR) + r"(?!/ometiffs/separate/)"
         )
 
+
 class NanoDESIConfBuilder(ImagePyramidViewConfBuilder):
     def __init__(self, entity, groups_token, assets_endpoint, **kwargs):
         super().__init__(entity, groups_token, assets_endpoint, **kwargs)
         # Do not show full pyramid - does not look good
-        image_names = [Path(file['rel_path']).name for file in self._entity["files"] if not file["rel_path"].endswith('json')]
+        image_names = [Path(file['rel_path']).name for file in self._entity["files"]
+                       if not file["rel_path"].endswith('json')]
         self.use_full_resolution = image_names
         self.use_physical_size_scaling = True
 

--- a/src/portal_visualization/builders/imaging_builders.py
+++ b/src/portal_visualization/builders/imaging_builders.py
@@ -98,7 +98,8 @@ class ImagePyramidViewConfBuilder(AbstractImagingViewConfBuilder):
                 use_physical_size_scaling=self.use_physical_size_scaling
             )
         )
-        vc = self._setup_view_config_raster(vc, dataset, use_full_resolution=self.use_full_resolution)
+        vc = self._setup_view_config_raster(
+            vc, dataset, use_full_resolution=self.use_full_resolution)
         conf = vc.to_dict()
         # Don't want to render all layers
         del conf["datasets"][0]["files"][0]["options"]["renderLayers"]

--- a/src/portal_visualization/builders/imaging_builders.py
+++ b/src/portal_visualization/builders/imaging_builders.py
@@ -46,9 +46,9 @@ class AbstractImagingViewConfBuilder(ViewConfBuilder):
             ),
         )
 
-    def _setup_view_config_raster(self, vc, dataset, disable_3d=[]):
+    def _setup_view_config_raster(self, vc, dataset, disable_3d=[], use_full_resolution=[]):
         vc.add_view(cm.SPATIAL, dataset=dataset, x=3, y=0, w=9, h=12).set_props(
-            useFullResolutionImage=self.use_full_resolution
+            useFullResolutionImage=use_full_resolution
         )
         vc.add_view(cm.DESCRIPTION, dataset=dataset, x=0, y=8, w=3, h=4)
         vc.add_view(cm.LAYER_CONTROLLER, dataset=dataset, x=0, y=0, w=3, h=8).set_props(
@@ -98,7 +98,7 @@ class ImagePyramidViewConfBuilder(AbstractImagingViewConfBuilder):
                 use_physical_size_scaling=self.use_physical_size_scaling
             )
         )
-        vc = self._setup_view_config_raster(vc, dataset)
+        vc = self._setup_view_config_raster(vc, dataset, use_full_resolution=self.use_full_resolution)
         conf = vc.to_dict()
         # Don't want to render all layers
         del conf["datasets"][0]["files"][0]["options"]["renderLayers"]
@@ -119,7 +119,7 @@ class IMSViewConfBuilder(ImagePyramidViewConfBuilder):
         )
 
 
-class NanoDESIConfBuilder(ImagePyramidViewConfBuilder):
+class NanoDESIViewConfBuilder(ImagePyramidViewConfBuilder):
     def __init__(self, entity, groups_token, assets_endpoint, **kwargs):
         super().__init__(entity, groups_token, assets_endpoint, **kwargs)
         # Do not show full pyramid - does not look good

--- a/test/bad-fixtures/image-pyramid-missing-ometiff-entity.json
+++ b/test/bad-fixtures/image-pyramid-missing-ometiff-entity.json
@@ -3,6 +3,11 @@
         "image_pyramid",
         "PAS"
     ],
+    "immediate_ancestors": [
+        {
+            "data_types": ["PAS"]
+        }
+    ],
     "status": "QA",
     "files": [
         {

--- a/test/good-fixtures/IMSViewConfBuilder/fake-conf.json
+++ b/test/good-fixtures/IMSViewConfBuilder/fake-conf.json
@@ -39,6 +39,9 @@
       "coordinationScopes": {
         "dataset": "A"
       },
+      "props": {
+        "useFullResolutionImage": []
+      },
       "h": 12,
       "w": 9,
       "x": 3,

--- a/test/good-fixtures/IMSViewConfBuilder/fake-entity.json
+++ b/test/good-fixtures/IMSViewConfBuilder/fake-entity.json
@@ -4,6 +4,11 @@
         "MALDI-IMS-neg"
     ],
     "status": "QA",
+    "immediate_ancestors": [
+        {
+            "data_types": ["MALDI-IMS-neg"]
+        }
+    ],
     "files": [
         {
             "rel_path": "ometiff-pyramids/ometiffs/separate/VAN0003-LK-32-21-IMS_NegMode_mz909.606.ome.tif"

--- a/test/good-fixtures/ImagePyramidViewConfBuilder/fake-conf.json
+++ b/test/good-fixtures/ImagePyramidViewConfBuilder/fake-conf.json
@@ -39,6 +39,9 @@
       "coordinationScopes": {
         "dataset": "A"
       },
+      "props": {
+        "useFullResolutionImage": []
+      },
       "h": 12,
       "w": 9,
       "x": 3,

--- a/test/good-fixtures/ImagePyramidViewConfBuilder/fake-entity.json
+++ b/test/good-fixtures/ImagePyramidViewConfBuilder/fake-entity.json
@@ -4,6 +4,11 @@
         "PAS"
     ],
     "status": "QA",
+    "immediate_ancestors": [
+        {
+            "data_types": ["PAS"]
+        }
+    ],
     "files": [
         {
             "rel_path": "ometiff-pyramids/processedMicroscopy/VAN0003-LK-33-2-PAS_FFPE.ome.tif"

--- a/test/good-fixtures/NanoDESIViewConfBuilder/fake-conf.json
+++ b/test/good-fixtures/NanoDESIViewConfBuilder/fake-conf.json
@@ -1,0 +1,75 @@
+{
+  "coordinationSpace": {
+    "dataset": {
+      "A": "A"
+    }
+  },
+  "datasets": [
+    {
+      "files": [
+        {
+          "fileType": "raster.json",
+          "options": {
+            "images": [
+              {
+                "metadata": {
+                  "isBitmask": false,
+                  "omeTiffOffsetsUrl": "https://example.com/954281e9fd8732adfa4479e0d238ce8d/output_offsets/ometiffs/VAN0003-LK-32-21-IMS_NegMode_multilayer.offsets.json?token=groups_token"
+                },
+                "name": "VAN0003-LK-32-21-IMS_NegMode_multilayer.ome.tif",
+                "type": "ome-tiff",
+                "url": "https://example.com/954281e9fd8732adfa4479e0d238ce8d/ometiff-pyramids/ometiffs/VAN0003-LK-32-21-IMS_NegMode_multilayer.ome.tif?token=groups_token"
+              }
+            ],
+            "schemaVersion": "0.0.2",
+            "usePhysicalSizeScaling": true
+          },
+          "type": "raster"
+        }
+      ],
+      "name": "Visualization Files",
+      "uid": "A"
+    }
+  ],
+  "description": "",
+  "initStrategy": "auto",
+  "layout": [
+    {
+      "component": "spatial",
+      "coordinationScopes": {
+        "dataset": "A",
+        "useFullResolutionImage": ["VAN0003-LK-32-21-IMS_NegMode_multilayer.ome.tif"]
+      },
+      "h": 12,
+      "w": 9,
+      "x": 3,
+      "y": 0
+    },
+    {
+      "component": "description",
+      "coordinationScopes": {
+        "dataset": "A"
+      },
+      "h": 4,
+      "w": 3,
+      "x": 0,
+      "y": 8
+    },
+    {
+      "component": "layerController",
+      "coordinationScopes": {
+        "dataset": "A"
+      },
+      "h": 8,
+      "props": {
+        "disable3d": [],
+        "disableChannelsIfRgbDetected": true
+      },
+      "w": 3,
+      "x": 0,
+      "y": 0
+    }
+  ],
+  "name": "HuBMAP Data Portal",
+  "version": "1.0.7"
+}

--- a/test/good-fixtures/NanoDESIViewConfBuilder/fake-conf.json
+++ b/test/good-fixtures/NanoDESIViewConfBuilder/fake-conf.json
@@ -37,7 +37,9 @@
     {
       "component": "spatial",
       "coordinationScopes": {
-        "dataset": "A",
+        "dataset": "A"
+      },
+      "props": {
         "useFullResolutionImage": ["VAN0003-LK-32-21-IMS_NegMode_multilayer.ome.tif"]
       },
       "h": 12,

--- a/test/good-fixtures/NanoDESIViewConfBuilder/fake-entity.json
+++ b/test/good-fixtures/NanoDESIViewConfBuilder/fake-entity.json
@@ -1,0 +1,17 @@
+{
+    "data_types": [
+        "image_pyramid",
+        "NanoDESI"
+    ],
+    "status": "QA",
+    "files": [
+        {
+            "rel_path": "ometiff-pyramids/ometiffs/VAN0003-LK-32-21-IMS_NegMode_multilayer.ome.tif"
+        },
+        {
+            "rel_path": "output_offsets/ometiffs/VAN0003-LK-32-21-IMS_NegMode_multilayer.offsets.json"
+        }
+    ],
+    "uuid": "954281e9fd8732adfa4479e0d238ce8d",
+    "metadata": {"dag_provenance_list": []}
+}

--- a/test/good-fixtures/NanoDESIViewConfBuilder/fake-entity.json
+++ b/test/good-fixtures/NanoDESIViewConfBuilder/fake-entity.json
@@ -1,7 +1,11 @@
 {
     "data_types": [
-        "image_pyramid",
-        "NanoDESI"
+        "image_pyramid"
+    ],
+    "immediate_ancestors": [
+        {
+            "data_types": ["NanoDESI"]
+        }
     ],
     "status": "QA",
     "files": [

--- a/test/good-fixtures/SeqFISHViewConfBuilder/fake-conf.json
+++ b/test/good-fixtures/SeqFISHViewConfBuilder/fake-conf.json
@@ -49,6 +49,9 @@
         "coordinationScopes": {
           "dataset": "A"
         },
+        "props": {
+          "useFullResolutionImage": []
+        },
         "h": 12,
         "w": 9,
         "x": 3,
@@ -134,6 +137,9 @@
         "component": "spatial",
         "coordinationScopes": {
           "dataset": "A"
+        },
+        "props": {
+          "useFullResolutionImage": []
         },
         "h": 12,
         "w": 9,

--- a/test/good-fixtures/SeqFISHViewConfBuilder/fake-entity.json
+++ b/test/good-fixtures/SeqFISHViewConfBuilder/fake-entity.json
@@ -4,6 +4,11 @@
         "seqFish"
     ],
     "status": "QA",
+    "immediate_ancestors": [
+        {
+            "data_types": ["seqFish"]
+        }
+    ],
     "files": [
         {
             "rel_path": "ometiff-pyramids/final_mRNA_background/MMStack_Pos12.ome.tif"

--- a/test/good-fixtures/TiledSPRMViewConfBuilder/no-cells-conf.json
+++ b/test/good-fixtures/TiledSPRMViewConfBuilder/no-cells-conf.json
@@ -39,6 +39,9 @@
         "coordinationScopes": {
           "dataset": "A"
         },
+        "props": {
+          "useFullResolutionImage": []
+        },
         "h": 12,
         "w": 9,
         "x": 3,

--- a/test/good-fixtures/TiledSPRMViewConfBuilder/no-cells-entity.json
+++ b/test/good-fixtures/TiledSPRMViewConfBuilder/no-cells-entity.json
@@ -7,6 +7,11 @@
       "rel_path": "output/extract/expressions/ome-tiff/reg1.ome.tiff"
     }
   ],
+  "immediate_ancestors": [
+        {
+            "data_types": ["codex_cytokit_v1"]
+        }
+  ],
   "mapped_data_types": [
     "CODEX [Cytokit + SPRM]"
   ],


### PR DESCRIPTION
**Goal**
To display NanoDESI datasets correctly (the difference should be quite apparent - they previously looked "squished")

**Changes**
- Add a the parameter for using the full resolution (`use_full_resolution`/`useFullResolutionImage`) to the view config because the lower resolutions of the image pyramid don't look great (at the expense of slightly slower display time)
- Make sure that physical size scaling is used for the `NanoDESI` so that the image gets resized

**Issues**
- ~~The line with the comment "very bad hack" is a problem.  `NanoDESI` does not appear to be in the data type key of the `entity`, which it should be as far as I understand.~~
- Unrelated, the upgraded view config has an erroneous `obsSegmentation` file although this doesn't affect visualization.  Will file a bug (https://github.com/vitessce/vitessce/issues/1598)

To test: any of these datasets http://localhost:5001/search?mapped_data_types[0]=NanoDESI&entity_type[0]=Dataset should now display correctly (compare to prod)