### PR TITLE
NickAkhmetov/Unpin nbformat version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     vitessce==3.5.4
     hubmap-commons>=2.0.15
     requests>=2.27.1
-    nbformat==5.1.3
+    nbformat>=5.1.3
     zarr>=2.17.2
     aiohttp>=3.8.1
     fsspec>=2022.1.0


### PR DESCRIPTION
This PR unpins `nbformat` from the specific patch version it has been pinned to for 3+ years to unblock an issue with HuBMAP workspaces.