### PR TITLE
NickAkhmetov/CAT-1419 Fix visualization overflows for spatial anndata

### DIFF
--- a/test/good-fixtures/RNASeqAnnDataZarrViewConfBuilder/fake-is-not-annotated-minimal-published-conf.json
+++ b/test/good-fixtures/RNASeqAnnDataZarrViewConfBuilder/fake-is-not-annotated-minimal-published-conf.json
@@ -95,14 +95,7 @@
     {
       "component": "obsSets",
       "coordinationScopes": {
-        "dataset": "A",
-        "obsLabelsType": [
-          "A",
-          "B",
-          "C",
-          "D",
-          "E"
-        ]
+        "dataset": "A"
       },
       "x": 6,
       "y": 0,

--- a/test/good-fixtures/SpatialRNASeqAnnDataZarrViewConfBuilder/ea4cfecb8495b36694d9a951510dc3c6-marker=gene123-cells.yaml
+++ b/test/good-fixtures/SpatialRNASeqAnnDataZarrViewConfBuilder/ea4cfecb8495b36694d9a951510dc3c6-marker=gene123-cells.yaml
@@ -63,7 +63,7 @@
         component="scatterplot",
         x=0,
         y=0,
-        w=4,
+        w=3,
         h=6,
         coordination_scopes={
             "embeddingType": "A",
@@ -74,9 +74,9 @@
     ).add_view(
         dataset_uid="A",
         component="obsSets",
-        x=9,
+        x=6,
         y=0,
-        w=0,
+        w=3,
         h=4,
         coordination_scopes={
             "obsLabelsType": ["A", "B", "C", "D", "E"],
@@ -86,7 +86,7 @@
     ).add_view(
         dataset_uid="A",
         component="featureList",
-        x=12,
+        x=9,
         y=0,
         w=3,
         h=4,
@@ -122,9 +122,9 @@
     ).add_view(
         dataset_uid="A",
         component="spatial",
-        x=4,
+        x=3,
         y=0,
-        w=5,
+        w=3,
         h=6,
         coordination_scopes={
             "spatialSegmentationLayer": "A",

--- a/test/good-fixtures/SpatialRNASeqAnnDataZarrViewConfBuilder/ea4cfecb8495b36694d9a951510dc3c6-marker=gene123-conf.json
+++ b/test/good-fixtures/SpatialRNASeqAnnDataZarrViewConfBuilder/ea4cfecb8495b36694d9a951510dc3c6-marker=gene123-conf.json
@@ -113,7 +113,7 @@
       },
       "x": 0,
       "y": 0,
-      "w": 4,
+      "w": 3,
       "h": 6
     },
     {
@@ -130,9 +130,9 @@
         "featureSelection": "A",
         "obsColorEncoding": "A"
       },
-      "x": 9,
+      "x": 6,
       "y": 0,
-      "w": 0,
+      "w": 3,
       "h": 4
     },
     {
@@ -149,7 +149,7 @@
         "featureSelection": "A",
         "obsColorEncoding": "A"
       },
-      "x": 12,
+      "x": 9,
       "y": 0,
       "w": 3,
       "h": 4
@@ -207,9 +207,9 @@
         "featureSelection": "A",
         "obsColorEncoding": "A"
       },
-      "x": 4,
+      "x": 3,
       "y": 0,
-      "w": 5,
+      "w": 3,
       "h": 6
     }
   ],

--- a/test/good-fixtures/SpatialRNASeqAnnDataZarrViewConfBuilder/ea4cfecb8495b36694d9a951510dc3c6-minimal-conf.json
+++ b/test/good-fixtures/SpatialRNASeqAnnDataZarrViewConfBuilder/ea4cfecb8495b36694d9a951510dc3c6-minimal-conf.json
@@ -100,24 +100,17 @@
       },
       "x": 0,
       "y": 0,
-      "w": 4,
-      "h": 12
+      "w": 6,
+      "h": 6
     },
     {
       "component": "obsSets",
       "coordinationScopes": {
-        "dataset": "A",
-        "obsLabelsType": [
-          "A",
-          "B",
-          "C",
-          "D",
-          "E"
-        ]
+        "dataset": "A"
       },
-      "x": 9,
+      "x": 6,
       "y": 0,
-      "w": 3,
+      "w": 6,
       "h": 4
     },
     {
@@ -150,10 +143,10 @@
           "E"
         ]
       },
-      "x": 4,
-      "y": 0,
-      "w": 5,
-      "h": 12
+      "x": 0,
+      "y": 6,
+      "w": 6,
+      "h": 6
     }
   ],
   "initStrategy": "auto"


### PR DESCRIPTION
This PR improves the builders for RNASeq anndata visualizations by simplifying the positioning logic for the visualization's components when accounting for spatial/non-spatial and minimal/non-minimal variants.

Minimal, non-spatial:
<img width="1180" height="710" alt="image" src="https://github.com/user-attachments/assets/d9a9b9c4-97c2-40f7-813a-8efaca8beb3d" />

Minimal, spatial:
<img width="1240" height="725" alt="image" src="https://github.com/user-attachments/assets/92d072fd-88a2-49dc-b630-527f3111ecff" />

Non-spatial:
<img width="1228" height="821" alt="image" src="https://github.com/user-attachments/assets/092ef838-69f9-40cb-9544-98f72ff77092" />

Spatial:
<img width="1242" height="842" alt="image" src="https://github.com/user-attachments/assets/002e5abf-03d7-453f-973e-000bc90406c5" />
