### PR TITLE
Enhance asset URL building and restore segmentation channel support for SPRM builders

### DIFF
--- a/src/portal_visualization/builders/base_builders.py
+++ b/src/portal_visualization/builders/base_builders.py
@@ -242,24 +242,39 @@ class ViewConfBuilder(ABC):
     def _build_assets_url(self, rel_path, use_token=True):
         """Create a url for an asset.
         :param str rel_path: The path off of which the url should be built
-        :param bool use_token: Whether or not to append a groups token to the URL, default True
+        :param bool use_token: Whether or not to append a groups token to the URL, default True.
+            The token is omitted for Published datasets regardless, since their assets are public.
         :rtype: dict The file with rel_path replaced by url
 
         >>> from pprint import pprint
         >>> builder = _DocTestBuilder(
-        ...   entity={ "uuid": "uuid" },
+        ...   entity={ "uuid": "uuid", "status": "QA" },
         ...   groups_token='groups_token',
         ...   assets_endpoint='https://example.com')
         >>> builder._build_assets_url("rel_path/to/clusters.ome.tiff")
         'https://example.com/uuid/rel_path/to/clusters.ome.tiff?token=groups_token'
+
+        Published datasets are public, so no (expiring) token is appended:
+
+        >>> builder = _DocTestBuilder(
+        ...   entity={ "uuid": "uuid", "status": "Published" },
+        ...   groups_token='groups_token',
+        ...   assets_endpoint='https://example.com')
+        >>> builder._build_assets_url("rel_path/to/clusters.ome.tiff")
+        'https://example.com/uuid/rel_path/to/clusters.ome.tiff'
 
         """
         uuid = self._uuid
         if hasattr(self, "_epic_uuid"):  # pragma: no cover
             uuid = self._epic_uuid
         base_url = urllib.parse.urljoin(self._assets_endpoint, f"{uuid}/{rel_path}")
+        # Published assets are public: the browser fetches them without auth, so an expiring token in
+        # the URL is unnecessary and breaks the saved config once it expires. Only non-published assets
+        # need the URL token (viv's image tile requests can't carry an Authorization header).
+        if not use_token or self._entity.get("status") == "Published":
+            return base_url
         token_param = urllib.parse.urlencode({"token": self._groups_token})
-        return f"{base_url}?{token_param}" if use_token else base_url
+        return f"{base_url}?{token_param}"
 
     def _get_request_init(self):
         """Get request headers for requestInit parameter in Vitessce conf.

--- a/src/portal_visualization/builders/sprm_builders.py
+++ b/src/portal_visualization/builders/sprm_builders.py
@@ -269,6 +269,32 @@ class SPRMAnnDataViewConfBuilder(SPRMViewConfBuilder):
         remaining = [i for i in range(size_c) if i not in seg_indices]
         return (seg_indices + remaining)[:num_channels]
 
+    def _build_segmentation_channels(self, bitmask_metadata):
+        """One segmentation channel per bitmask channel, mirroring the front-end's
+        obsTypesFromChannelNames auto-init so every mask -- for CODEX: cells, nuclei, cell_boundaries,
+        nucleus_boundaries -- is listed and toggleable, not just the cell mask. The cell mask keeps
+        obsType "cell" so it colors by the selected cell set (joining the AnnData cells); the others
+        render in their own channel color. Falls back to a single channel when the mask (or the mocked
+        metadata) exposes no channel names."""
+        names = (bitmask_metadata or {}).get("ChannelNames") or []
+        size_c = (bitmask_metadata or {}).get("SizeC") or 1
+        channels = []
+        for c in range(min(size_c, MAX_IMAGE_CHANNELS)):
+            name = names[c] if c < len(names) and names[c] else f"segmentation-{c}"
+            is_cell = name.lower() in ("cell", "cells")
+            channels.append(
+                {
+                    "spatialTargetC": c,
+                    "obsType": "cell" if is_cell else name,
+                    "spatialChannelColor": IMAGE_CHANNEL_COLORS[c],
+                    "spatialChannelVisible": True,
+                    "spatialChannelOpacity": 1.0,
+                    "spatialSegmentationFilled": True,
+                    "obsColorEncoding": "cellSetSelection" if is_cell else "spatialChannelColor",
+                }
+            )
+        return channels
+
     def _build_description(self, image_metadata, n_obs):
         """Summary text for the description view: OME-TIFF header info plus the cell count."""
         lines = [self._image_name]
@@ -387,6 +413,7 @@ class SPRMAnnDataViewConfBuilder(SPRMViewConfBuilder):
             marker,
             n_obs=n_obs,
             channel_indices=channel_indices,
+            segmentation_channels=self._build_segmentation_channels(bitmask_metadata),
             embedding_name=embedding_name,
             prioritized_selection=prioritized_selection,
             description_text=self._build_description(image_metadata, n_obs),
@@ -400,6 +427,7 @@ class SPRMAnnDataViewConfBuilder(SPRMViewConfBuilder):
         marker,
         n_obs=0,
         channel_indices=(0,),
+        segmentation_channels=None,
         embedding_name="t-SNE",
         prioritized_selection=None,
         description_text="",
@@ -492,20 +520,7 @@ class SPRMAnnDataViewConfBuilder(SPRMViewConfBuilder):
                             "fileUid": "segmentation-mask",
                             "spatialLayerVisible": True,
                             "spatialLayerOpacity": 1.0,
-                            "segmentationChannel": CL(
-                                [
-                                    {
-                                        # ponytail: channel 0 assumed to be the cell mask; obsType "cell"
-                                        # joins it to the AnnData cells so it colors by the selected cell set.
-                                        "spatialTargetC": 0,
-                                        "obsType": "cell",
-                                        "spatialChannelOpacity": 1.0,
-                                        "spatialChannelVisible": True,
-                                        "obsColorEncoding": "cellSetSelection",
-                                        "spatialSegmentationFilled": True,
-                                    }
-                                ]
-                            ),
+                            "segmentationChannel": CL(segmentation_channels),
                         }
                     ]
                 )

--- a/src/portal_visualization/builders/sprm_builders.py
+++ b/src/portal_visualization/builders/sprm_builders.py
@@ -274,8 +274,10 @@ class SPRMAnnDataViewConfBuilder(SPRMViewConfBuilder):
         obsTypesFromChannelNames auto-init so every mask -- for CODEX: cells, nuclei, cell_boundaries,
         nucleus_boundaries -- is listed and toggleable, not just the cell mask. The cell mask keeps
         obsType "cell" so it colors by the selected cell set (joining the AnnData cells); the others
-        render in their own channel color. Falls back to a single channel when the mask (or the mocked
-        metadata) exposes no channel names."""
+        render in their own channel color. Their obsType doubles as the layer-controller label, so
+        humanize the raw channel name (e.g. "cell_boundaries" -> "Cell Boundaries"); Vitessce only
+        capitalizes the first character, so it would otherwise show the snake_case name verbatim.
+        Falls back to a single channel when the mask (or the mocked metadata) exposes no channel names."""
         names = (bitmask_metadata or {}).get("ChannelNames") or []
         size_c = (bitmask_metadata or {}).get("SizeC") or 1
         channels = []
@@ -285,7 +287,7 @@ class SPRMAnnDataViewConfBuilder(SPRMViewConfBuilder):
             channels.append(
                 {
                     "spatialTargetC": c,
-                    "obsType": "cell" if is_cell else name,
+                    "obsType": "cell" if is_cell else name.replace("_", " ").title(),
                     "spatialChannelColor": IMAGE_CHANNEL_COLORS[c],
                     "spatialChannelVisible": True,
                     "spatialChannelOpacity": 1.0,

--- a/src/portal_visualization/builders/sprm_builders.py
+++ b/src/portal_visualization/builders/sprm_builders.py
@@ -490,6 +490,10 @@ class SPRMAnnDataViewConfBuilder(SPRMViewConfBuilder):
                 "spatialChannelColor": IMAGE_CHANNEL_COLORS[position],
                 "spatialChannelVisible": True,
                 "spatialChannelOpacity": 1.0,
+                # Declare the contrast window per channel (None -> Vitessce auto-computes it). Without
+                # it there is no per-channel window scope, so all channels share one and their min/max
+                # sliders move together.
+                "spatialChannelWindow": None,
             }
             for position, channel in enumerate(channel_indices)
         ]

--- a/src/portal_visualization/builders/sprm_builders.py
+++ b/src/portal_visualization/builders/sprm_builders.py
@@ -459,25 +459,35 @@ class SPRMAnnDataViewConfBuilder(SPRMViewConfBuilder):
 
         vc.link_views(views, [CoordinationType.OBS_TYPE], ["cell"])
 
-        if marker:
-            vc.link_views(
-                views,
-                [CoordinationType.FEATURE_SELECTION, CoordinationType.OBS_COLOR_ENCODING],
-                [[marker], "geneSelection"],
-            )
-        else:
-            # Color cells (scatterplot + segmentation) by the selected cell set.
-            [obs_color_encoding] = vc.add_coordination(CoordinationType.OBS_COLOR_ENCODING)
-            obs_color_encoding.set_value("cellSetSelection")
-            for view in (spatial, scatterplot, cell_sets):
-                view.use_coordination(obs_color_encoding)
-            # Preselect/color by the embedding's matching clustering (UMAP if present, else t-SNE),
-            # enumerating each cluster ID so the whole clustering is selected initially.
-            if prioritized_selection:
-                [obs_set_selection] = vc.add_coordination(CoordinationType.OBS_SET_SELECTION)
-                obs_set_selection.set_value(prioritized_selection)
-                for view in (spatial, scatterplot, cell_sets):
-                    view.use_coordination(obs_set_selection)
+        # One shared cell-coloring coordination, referenced by the scatterplot, the antigen (feature)
+        # list, the cell-set list, and the cell segmentation channel. Selecting a gene in the feature
+        # list sets obsColorEncoding=geneSelection + featureSelection; selecting a cell set sets
+        # obsColorEncoding=cellSetSelection + obsSetSelection -- all on the SAME scopes, so the
+        # scatterplot and the spatial (segmentation) cells recolor together either way.
+        [obs_color_encoding] = vc.add_coordination(CoordinationType.OBS_COLOR_ENCODING)
+        [feature_selection] = vc.add_coordination(CoordinationType.FEATURE_SELECTION)
+        [obs_set_selection] = vc.add_coordination(CoordinationType.OBS_SET_SELECTION)
+        obs_color_encoding.set_value("geneSelection" if marker else "cellSetSelection")
+        feature_selection.set_value([marker] if marker else None)
+        # Preselect the embedding's matching clustering (UMAP if present, else t-SNE) when available.
+        obs_set_selection.set_value(prioritized_selection)
+
+        scatterplot.use_coordination(obs_color_encoding, feature_selection, obs_set_selection)
+        spatial.use_coordination(obs_color_encoding, feature_selection, obs_set_selection)
+        cell_sets.use_coordination(obs_color_encoding, obs_set_selection)
+        gene_list.use_coordination(obs_color_encoding, feature_selection)
+        if include_heatmap:
+            heatmap.use_coordination(feature_selection)
+
+        # Route the cell mask's coloring through the same shared scopes (instead of a fixed
+        # cellSetSelection) so the spatial segmentation follows the scatterplot/list selection. The
+        # other masks (nuclei, boundaries) keep their static spatialChannelColor -- they have no
+        # per-cell data to color by.
+        for channel in segmentation_channels or []:
+            if channel.get("obsType") == "cell":
+                channel["obsColorEncoding"] = obs_color_encoding
+                channel["featureSelection"] = feature_selection
+                channel["obsSetSelection"] = obs_set_selection
 
         # Wire the image and segmentation layers into the beta views. The beta spatial model does not
         # auto-discover channels, so each channel is listed explicitly (an empty/partial channel list

--- a/src/portal_visualization/constants.py
+++ b/src/portal_visualization/constants.py
@@ -12,7 +12,7 @@ MULTIOMIC_ZARR_PATH = "hubmap_ui/mudata-zarr/secondary_analysis.zarr"
 XENIUM_ZARR_PATH = "Xenium.zarr"
 
 # Maximum number of observations to display heatmaps for performance reasons
-MAX_OBS_FOR_HEATMAP = 100_000
+MAX_OBS_FOR_HEATMAP = 125_000
 
 # User-Agent sent on server-side requests made while building a Vitessce config. It must NOT match
 # the back-end's scraping filter, so the config builder's traffic can be whitelisted:

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -1712,15 +1712,16 @@ def test_sprm_segmentation_channels_from_bitmask():
     named = builder._build_segmentation_channels(
         {"SizeC": 4, "ChannelNames": ["cells", "nuclei", "cell_boundaries", "nucleus_boundaries"]}
     )
-    assert [c["obsType"] for c in named] == ["cell", "nuclei", "cell_boundaries", "nucleus_boundaries"]
+    # Cell mask keeps obsType "cell" (AnnData join); the rest are humanized for the layer-controller label.
+    assert [c["obsType"] for c in named] == ["cell", "Nuclei", "Cell Boundaries", "Nucleus Boundaries"]
     assert named[0]["obsColorEncoding"] == "cellSetSelection"
     assert all(c["obsColorEncoding"] == "spatialChannelColor" for c in named[1:])
     assert all(c["spatialChannelVisible"] and c["spatialSegmentationFilled"] for c in named)
 
     # No channel names -> index-named fallbacks, none treated as the cell mask; None -> single channel.
     assert [c["obsType"] for c in builder._build_segmentation_channels({"SizeC": 2})] == [
-        "segmentation-0",
-        "segmentation-1",
+        "Segmentation-0",
+        "Segmentation-1",
     ]
     assert builder._build_segmentation_channels(None) == builder._build_segmentation_channels({"SizeC": 1})
 
@@ -2238,7 +2239,7 @@ def test_sprm_anndata_heatmap_gate_and_prioritized_cell_set():
     # mask -- so the nucleus/boundary masks are no longer dropped from the config.
     obs_types = list(conf["coordinationSpace"].get("obsType", {}).values())
     assert "cell" in obs_types
-    assert "nuclei" in obs_types
+    assert "Nuclei" in obs_types
     assert "layerControllerBeta" in layout_str
     assert conf["coordinationSpace"]["obsSetSelection"]["A"] == prioritized_selection
     assert conf["coordinationSpace"]["embeddingType"]["A"] == "UMAP"

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -2243,6 +2243,16 @@ def test_sprm_anndata_heatmap_gate_and_prioritized_cell_set():
     assert "layerControllerBeta" in layout_str
     assert conf["coordinationSpace"]["obsSetSelection"]["A"] == prioritized_selection
     assert conf["coordinationSpace"]["embeddingType"]["A"] == "UMAP"
+    # Gene/cell-set selection must recolor both the scatterplot and the spatial cells: the scatterplot,
+    # feature list, cell-set list, and the cell segmentation channel share one obsColorEncoding scope.
+    scopes = {v["component"]: v["coordinationScopes"] for v in conf["layout"]}
+    shared_oce = scopes["scatterplot"]["obsColorEncoding"]
+    assert scopes["featureList"]["obsColorEncoding"] == shared_oce
+    assert scopes["obsSets"]["obsColorEncoding"] == shared_oce
+    assert scopes["featureList"]["featureSelection"] == scopes["scatterplot"]["featureSelection"]
+    seg_key = next(k for k in conf["coordinationSpace"]["metaCoordinationScopesBy"] if "obsSegmentations" in k)
+    seg_oce = conf["coordinationSpace"]["metaCoordinationScopesBy"][seg_key]["segmentationChannel"]["obsColorEncoding"]
+    assert shared_oce in seg_oce.values()  # cell mask follows the same encoding
     # First 6 image channels, each with its distinct color.
     channel_colors = list(conf["coordinationSpace"].get("spatialChannelColor", {}).values())
     for color in IMAGE_CHANNEL_COLORS:

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -359,6 +359,7 @@ def mock_zarr_store(entity_path, mocker, obs_count):
     # Mock image metadata retrieval (used by imaging builders, harmless for others)
     mocker.patch("src.portal_visualization.builders.imaging_builders.get_image_metadata", return_value=None)
     mocker.patch("src.portal_visualization.builders.epic_builders.get_image_metadata", return_value=None)
+
     # SPRM builders read OME-TIFF headers for both the expression image and the segmentation mask.
     # The mask exposes named channels (CODEX: cells/nuclei/cell_boundaries/nucleus_boundaries) that
     # drive one segmentation layer each; return those for mask URLs so the fan-out is exercised, and
@@ -2222,9 +2223,7 @@ def test_sprm_anndata_heatmap_gate_and_prioritized_cell_set():
         marker=None,
         n_obs=150_000,
         channel_indices=list(range(6)),
-        segmentation_channels=builder._build_segmentation_channels(
-            {"SizeC": 2, "ChannelNames": ["cells", "nuclei"]}
-        ),
+        segmentation_channels=builder._build_segmentation_channels({"SizeC": 2, "ChannelNames": ["cells", "nuclei"]}),
         embedding_name=UMAP_EMBEDDING[1],
         prioritized_selection=prioritized_selection,
         description_text=description_text,

--- a/test/test_builders.py
+++ b/test/test_builders.py
@@ -359,7 +359,19 @@ def mock_zarr_store(entity_path, mocker, obs_count):
     # Mock image metadata retrieval (used by imaging builders, harmless for others)
     mocker.patch("src.portal_visualization.builders.imaging_builders.get_image_metadata", return_value=None)
     mocker.patch("src.portal_visualization.builders.epic_builders.get_image_metadata", return_value=None)
-    mocker.patch("src.portal_visualization.builders.sprm_builders.get_ome_tiff_metadata", return_value=None)
+    # SPRM builders read OME-TIFF headers for both the expression image and the segmentation mask.
+    # The mask exposes named channels (CODEX: cells/nuclei/cell_boundaries/nucleus_boundaries) that
+    # drive one segmentation layer each; return those for mask URLs so the fan-out is exercised, and
+    # keep the expression image header empty (None) as before.
+    def _sprm_ome_tiff_metadata(url, *args, **kwargs):
+        if "mask" in url:
+            return {"SizeC": 4, "ChannelNames": ["cells", "nuclei", "cell_boundaries", "nucleus_boundaries"]}
+        return None
+
+    mocker.patch(
+        "src.portal_visualization.builders.sprm_builders.get_ome_tiff_metadata",
+        side_effect=_sprm_ome_tiff_metadata,
+    )
     # Multi-image base builders (SeqFISH) read the channel count from the first image's OME-TIFF.
     mocker.patch("src.portal_visualization.builders.imaging_builders.get_ome_tiff_metadata", return_value={"SizeC": 3})
     # Mock read_metadata_from_url (SegmentationMaskBuilder fetches zarr metadata over HTTP)
@@ -1680,6 +1692,39 @@ def test_sprm_builds_when_zarr_store_unavailable(mocker):
 
 # requires_full: imports sprm_builders, whose module-level `import numpy` is absent in the thin install.
 @pytest.mark.requires_full
+def test_sprm_segmentation_channels_from_bitmask():
+    """Each bitmask channel becomes its own segmentation layer; the cell mask joins the AnnData cells
+    (obsType 'cell', cell-set coloring) while the rest render in their own channel color. Missing/absent
+    channel names fall back to index-named channels."""
+    from src.portal_visualization.builders.sprm_builders import SPRMAnnDataViewConfBuilder
+
+    builder = SPRMAnnDataViewConfBuilder(
+        {"uuid": "u", "status": "QA", "files": []},
+        "token",
+        "https://example.com",
+        base_name="reg1",
+        image_name="reg1_expr",
+        mask_name="reg1_mask",
+        imaging_path="expr",
+        mask_path="mask",
+    )
+    named = builder._build_segmentation_channels(
+        {"SizeC": 4, "ChannelNames": ["cells", "nuclei", "cell_boundaries", "nucleus_boundaries"]}
+    )
+    assert [c["obsType"] for c in named] == ["cell", "nuclei", "cell_boundaries", "nucleus_boundaries"]
+    assert named[0]["obsColorEncoding"] == "cellSetSelection"
+    assert all(c["obsColorEncoding"] == "spatialChannelColor" for c in named[1:])
+    assert all(c["spatialChannelVisible"] and c["spatialSegmentationFilled"] for c in named)
+
+    # No channel names -> index-named fallbacks, none treated as the cell mask; None -> single channel.
+    assert [c["obsType"] for c in builder._build_segmentation_channels({"SizeC": 2})] == [
+        "segmentation-0",
+        "segmentation-1",
+    ]
+    assert builder._build_segmentation_channels(None) == builder._build_segmentation_channels({"SizeC": 1})
+
+
+@pytest.mark.requires_full
 def test_multiregion_sprm_preserves_region_order(mocker):
     """Regions build concurrently (ThreadPoolExecutor), but the aggregated config list must stay in
     sorted region order regardless of which thread finishes first — else per-region views get shuffled."""
@@ -2177,6 +2222,9 @@ def test_sprm_anndata_heatmap_gate_and_prioritized_cell_set():
         marker=None,
         n_obs=150_000,
         channel_indices=list(range(6)),
+        segmentation_channels=builder._build_segmentation_channels(
+            {"SizeC": 2, "ChannelNames": ["cells", "nuclei"]}
+        ),
         embedding_name=UMAP_EMBEDDING[1],
         prioritized_selection=prioritized_selection,
         description_text=description_text,
@@ -2187,6 +2235,11 @@ def test_sprm_anndata_heatmap_gate_and_prioritized_cell_set():
     layout_str = json.dumps(conf["layout"])
     assert "heatmap" not in layout_str.lower()
     assert "spatialBeta" in layout_str
+    # Every mask channel becomes its own segmentation layer (obsType per channel) -- not just the cell
+    # mask -- so the nucleus/boundary masks are no longer dropped from the config.
+    obs_types = list(conf["coordinationSpace"].get("obsType", {}).values())
+    assert "cell" in obs_types
+    assert "nuclei" in obs_types
     assert "layerControllerBeta" in layout_str
     assert conf["coordinationSpace"]["obsSetSelection"]["A"] == prioritized_selection
     assert conf["coordinationSpace"]["embeddingType"]["A"] == "UMAP"
@@ -2197,7 +2250,9 @@ def test_sprm_anndata_heatmap_gate_and_prioritized_cell_set():
 
     # Small dataset: heatmap present.
     vc2, dataset2 = builder._create_vitessce_config(name="r1", dataset_name="SPRM")
-    builder._setup_view_config_raster_cellsets_expression_segmentation(vc2, dataset2, marker=None, n_obs=5)
+    builder._setup_view_config_raster_cellsets_expression_segmentation(
+        vc2, dataset2, marker=None, n_obs=5, segmentation_channels=builder._build_segmentation_channels(None)
+    )
     assert "heatmap" in json.dumps(vc2.to_dict()["layout"]).lower()
 
 


### PR DESCRIPTION
This PR:

* Prevents tokens from being appended to public data URLs
* Fixes the SPRM builders not displaying the segmentation masks